### PR TITLE
Fix range sizes modern marching cubes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,8 +36,8 @@ OFILES= -o nii2mesh
 WASM := -s DEMANGLE_SUPPORT=1 -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "FS_createDataFile", "FS_readFile", "FS_unlink"]' -s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s EXPORTED_FUNCTIONS='["_simplify"]'
 
 # Modern marching cubes (vs classic)
-# MFILES= MarchingCubes.c
-MFILES= -DUSE_CLASSIC_CUBES oldcubes.c
+MFILES= MarchingCubes.c
+# MFILES= -DUSE_CLASSIC_CUBES oldcubes.c
 
 # GIfTI, obj, vtk, stl, etc support
 GFILES= -DHAVE_FORMATS base64.c

--- a/src/MarchingCubes.c
+++ b/src/MarchingCubes.c
@@ -1068,9 +1068,9 @@ int add_c_vertex( MCB *mcb)
 #ifdef NII2MESH
 int marchingCubes(float * img, short dim[3], int lo[3], int hi[3], int originalMC, float isolevel, vec3d **vs, vec3i **ts, int *nv, int *nt) {
   MCB * mcp = MarchingCubes(-1, -1, -1);
-  int NX = hi[0] - lo[0] + 1;
-  int NY = hi[1] - lo[1] + 1;
-  int NZ = hi[2] - lo[2] + 1;
+  int NX = dim[0];
+  int NY = dim[1];
+  int NZ = dim[2];
   set_resolution( mcp, NX, NY, NZ) ;
   init_all(mcp) ;
   float * im = mcp->data;


### PR DESCRIPTION
## Summary
Fixes a crash in Modern Marching Cubes when isosurface reaches the maximum boundary of the volume.

## The Problem
The calculation for range sizes ($NX, NY, NZ$) currently uses:
`hi[i] - lo[i] + 1`

When the isosurface hits the maximum dimension (`hi[i] == dim[i]`), this causes an **out-of-bounds crash**. The classic implementation correctly uses `dim[i]` without the `+1` offset.

## Changes
* Fixed range size calculations to match the Classic Marching Cubes logic.